### PR TITLE
Change battery_paths to a get method (function)

### DIFF
--- a/tripplite/__init__.py
+++ b/tripplite/__init__.py
@@ -4,7 +4,7 @@ Python driver for TrippLite UPS battery backups.
 Distributed under the GNU General Public License v2
 Copyright (C) 2018 NuMat Technologies
 """
-from tripplite.driver import Battery, battery_paths
+from tripplite.driver import Battery, get_battery_paths
 
 
 def command_line():
@@ -13,6 +13,7 @@ def command_line():
     import json
 
     argparse.ArgumentParser(description="Read TrippLite devices.")
+    battery_paths = get_battery_paths()
 
     if not battery_paths:
         raise IOError("No TrippLite devices found.")

--- a/tripplite/driver.py
+++ b/tripplite/driver.py
@@ -3,12 +3,13 @@ import hid
 
 vendor_id = 0x09ae
 
-# These change on each call to `hid.enumerate` so must be cached.
-battery_paths = [
-    device['path'].decode()
-    for device in hid.enumerate()
-    if device['vendor_id'] == vendor_id
-]
+def get_battery_paths():
+    # These change on each call to `hid.enumerate` so must be cached.
+    return [
+        device['path'].decode()
+        for device in hid.enumerate()
+        if device['vendor_id'] == vendor_id
+    ]
 
 structure = {
     'config': {

--- a/tripplite/driver.py
+++ b/tripplite/driver.py
@@ -1,7 +1,9 @@
 """Driver for TrippLite UPS battery backups."""
 import hid
 
+battery_paths = None
 vendor_id = 0x09ae
+
 
 def get_battery_paths():
     # These change on each call to `hid.enumerate` so must be cached.
@@ -10,6 +12,7 @@ def get_battery_paths():
         for device in hid.enumerate()
         if device['vendor_id'] == vendor_id
     ]
+
 
 structure = {
     'config': {
@@ -94,7 +97,7 @@ class Battery(object):
         """
         self.device = hid.device()
         if not battery_paths:
-            raise IOError("Could not find any connected TrippLite devices.")
+            get_battery_paths()
         if path is not None and path not in battery_paths:
             raise ValueError(f"Path {path} not in {', '.join(battery_paths)}.")
         self.path = path or battery_paths[0]


### PR DESCRIPTION
- On long running processes that import battery_paths can break when the HID devices change
- Let's not cache at import time (always good in Python to do as little as possible @ import time)
- Let's offer a function for importing code to use to 'refresh' the battery path at a sane rate
- updated __init__.py to use this new method / function