### PR TITLE
Ignore device_id for prometheus stats

### DIFF
--- a/tripplite/prometheus.py
+++ b/tripplite/prometheus.py
@@ -63,6 +63,10 @@ class PrometheusCollector(Collector):
             return
 
         for category, value in ups_data.items():
+            # Device USB ID is not of interest - lets ignore it
+            if category == "device_id":
+                continue
+
             if isinstance(value, int):
                 yield self._handle_counter(category, value)
             else:

--- a/tripplite/prometheus.py
+++ b/tripplite/prometheus.py
@@ -63,7 +63,7 @@ class PrometheusCollector(Collector):
             return
 
         for category, value in ups_data.items():
-            # Device USB ID is not of interest - lets ignore it
+            # Device USB ID is not of interest - ignore it
             if category == "device_id":
                 continue
 


### PR DESCRIPTION
A device ID can be a non valid float/int so lets ignore it when exporting prometheus metrics.

I moved a UPS to USB hub and this made the device ID unusable for promtheus stats. I also don't feel it's that useful to store. I could be open to normalizing it if people keep it's useful.

Test:
- Install on by box and see error dissapear when starting + pulling metrics